### PR TITLE
Add link button for mobile

### DIFF
--- a/application/features/editor/src/androidMain/kotlin/io/writeopia/editor/features/editor/ui/screen/NoteEditorScreen.android.kt
+++ b/application/features/editor/src/androidMain/kotlin/io/writeopia/editor/features/editor/ui/screen/NoteEditorScreen.android.kt
@@ -166,7 +166,8 @@ internal fun NoteEditorScreen(
                     noteEditorViewModel::cutSelection,
                     noteEditorViewModel::clearSelections,
                     noteEditorViewModel::onAddCheckListClick,
-                    noteEditorViewModel::onAddListItemClick
+                    noteEditorViewModel::onAddListItemClick,
+                    noteEditorViewModel::addPage,
                 )
             }
 
@@ -323,7 +324,8 @@ private fun BottomScreen(
     cutSelection: () -> Unit = {},
     onClose: () -> Unit = {},
     onCheckItem: () -> Unit = {},
-    onListItem: () -> Unit = {}
+    onListItem: () -> Unit = {},
+    onAddPage: () -> Unit = {},
 ) {
     val edit by editState.collectAsState()
 
@@ -367,7 +369,8 @@ private fun BottomScreen(
                     onCut = cutSelection,
                     onClose = onClose,
                     checkboxClick = onCheckItem,
-                    listItemClick = onListItem
+                    listItemClick = onListItem,
+                    onAddPage = onAddPage,
                 )
             }
         }

--- a/application/features/editor/src/commonMain/kotlin/io/writeopia/editor/features/editor/ui/desktop/edit/menu/SideEditorOptions.kt
+++ b/application/features/editor/src/commonMain/kotlin/io/writeopia/editor/features/editor/ui/desktop/edit/menu/SideEditorOptions.kt
@@ -658,7 +658,7 @@ private fun TextOptions(
 
         Title(WrStrings.links())
         Spacer(modifier = Modifier.height(4.dp))
-        IconAndText(WrStrings.page(), WrIcons.file, addPage)
+        IconAndText(WrStrings.page(), WrSdkIcons.linkPage, addPage)
     }
 }
 

--- a/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/components/EditionScreen.kt
+++ b/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/components/EditionScreen.kt
@@ -1,12 +1,14 @@
 package io.writeopia.ui.components
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ContentCut
 import androidx.compose.material.icons.filled.DeleteOutline
@@ -36,8 +38,8 @@ fun EditionScreen(
     onDelete: () -> Unit = {},
     onCopy: () -> Unit = {},
     onCut: () -> Unit = {},
-    onClose: () -> Unit = {},
     onAddPage: () -> Unit = {},
+    onClose: () -> Unit = {},
 ) {
     val iconPadding = PaddingValues(vertical = 4.dp)
     val clipShape = MaterialTheme.shapes.medium
@@ -47,132 +49,137 @@ fun EditionScreen(
     Row(modifier = modifier.padding(8.dp), verticalAlignment = Alignment.CenterVertically) {
         val tint = MaterialTheme.colorScheme.onPrimary
 
-        Icon(
+        Row(
             modifier = Modifier
-                .clip(clipShape)
-                .clickable {
-                    onSpanClick(Span.BOLD)
-                }
-                .size(iconSize)
-                .padding(iconPadding),
-            imageVector = Icons.Outlined.FormatBold,
-            contentDescription = "BOLD",
+                .weight(1f)
+                .horizontalScroll(rememberScrollState()),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                modifier = Modifier
+                    .clip(clipShape)
+                    .clickable {
+                        onSpanClick(Span.BOLD)
+                    }
+                    .size(iconSize)
+                    .padding(iconPadding),
+                imageVector = Icons.Outlined.FormatBold,
+                contentDescription = "BOLD",
 //            contentDescription = stringResource(R.string.delete),
-            tint = tint
-        )
+                tint = tint
+            )
 
-        Icon(
-            modifier = Modifier
-                .clip(clipShape)
-                .clickable {
-                    onSpanClick(Span.ITALIC)
-                }
-                .size(iconSize)
-                .padding(iconPadding),
-            imageVector = Icons.Outlined.FormatItalic,
-            contentDescription = "ITALIC",
+            Icon(
+                modifier = Modifier
+                    .clip(clipShape)
+                    .clickable {
+                        onSpanClick(Span.ITALIC)
+                    }
+                    .size(iconSize)
+                    .padding(iconPadding),
+                imageVector = Icons.Outlined.FormatItalic,
+                contentDescription = "ITALIC",
 //            contentDescription = stringResource(R.string.delete),
-            tint = tint
-        )
+                tint = tint
+            )
 
-        Spacer(modifier = Modifier.width(spaceWidth))
+            Spacer(modifier = Modifier.width(spaceWidth))
 
-        Icon(
-            modifier = Modifier
-                .clip(clipShape)
-                .clickable {
-                    onSpanClick(Span.UNDERLINE)
-                }
-                .size(iconSize)
-                .padding(iconPadding),
-            imageVector = Icons.Outlined.FormatUnderlined,
-            contentDescription = "UNDERLINE",
+            Icon(
+                modifier = Modifier
+                    .clip(clipShape)
+                    .clickable {
+                        onSpanClick(Span.UNDERLINE)
+                    }
+                    .size(iconSize)
+                    .padding(iconPadding),
+                imageVector = Icons.Outlined.FormatUnderlined,
+                contentDescription = "UNDERLINE",
 //            contentDescription = stringResource(R.string.delete),
-            tint = tint
-        )
+                tint = tint
+            )
 
-        Spacer(modifier = Modifier.width(spaceWidth))
+            Spacer(modifier = Modifier.width(spaceWidth))
 
-        Icon(
-            modifier = Modifier
-                .clip(clipShape)
-                .clickable(onClick = checkboxClick)
-                .size(iconSize)
-                .padding(iconPadding),
-            imageVector = WrSdkIcons.checkbox,
-            contentDescription = "Checkbox",
+            Icon(
+                modifier = Modifier
+                    .clip(clipShape)
+                    .clickable(onClick = checkboxClick)
+                    .size(iconSize)
+                    .padding(iconPadding),
+                imageVector = WrSdkIcons.checkbox,
+                contentDescription = "Checkbox",
 //            contentDescription = stringResource(R.string.delete),
-            tint = tint
-        )
+                tint = tint
+            )
 
-        Spacer(modifier = Modifier.width(spaceWidth))
+            Spacer(modifier = Modifier.width(spaceWidth))
 
-        Icon(
-            modifier = Modifier
-                .clip(clipShape)
-                .clickable(onClick = listItemClick)
-                .size(iconSize)
-                .padding(iconPadding),
-            imageVector = WrSdkIcons.list,
-            contentDescription = "List item",
+            Icon(
+                modifier = Modifier
+                    .clip(clipShape)
+                    .clickable(onClick = listItemClick)
+                    .size(iconSize)
+                    .padding(iconPadding),
+                imageVector = WrSdkIcons.list,
+                contentDescription = "List item",
 //            contentDescription = stringResource(R.string.delete),
-            tint = tint
-        )
+                tint = tint
+            )
 
-        Spacer(modifier = Modifier.width(spaceWidth))
+            Spacer(modifier = Modifier.width(spaceWidth))
 
-        Icon(
-            modifier = Modifier
-                .clip(clipShape)
-                .clickable(onClick = onCopy)
-                .size(32.dp)
-                .padding(iconPadding),
-            imageVector = WrSdkIcons.copy,
-            contentDescription = "Copy",
-            tint = tint
-        )
+            Icon(
+                modifier = Modifier
+                    .clip(clipShape)
+                    .clickable(onClick = onCopy)
+                    .size(32.dp)
+                    .padding(iconPadding),
+                imageVector = WrSdkIcons.copy,
+                contentDescription = "Copy",
+                tint = tint
+            )
 
-        Spacer(modifier = Modifier.width(spaceWidth))
+            Spacer(modifier = Modifier.width(spaceWidth))
 
-        Icon(
-            modifier = Modifier
-                .clip(clipShape)
-                .clickable(onClick = onCut)
-                .size(32.dp)
-                .padding(iconPadding),
-            imageVector = Icons.Default.ContentCut,
-            contentDescription = "Cut",
-            tint = tint
-        )
+            Icon(
+                modifier = Modifier
+                    .clip(clipShape)
+                    .clickable(onClick = onCut)
+                    .size(32.dp)
+                    .padding(iconPadding),
+                imageVector = Icons.Default.ContentCut,
+                contentDescription = "Cut",
+                tint = tint
+            )
 
-        Spacer(modifier = Modifier.width(spaceWidth))
+            Spacer(modifier = Modifier.width(spaceWidth))
 
-        Icon(
-            modifier = Modifier
-                .clip(clipShape)
-                .clickable(onClick = onDelete)
-                .size(iconSize)
-                .padding(iconPadding),
-            imageVector = Icons.Default.DeleteOutline,
-            contentDescription = "Delete",
+            Icon(
+                modifier = Modifier
+                    .clip(clipShape)
+                    .clickable(onClick = onDelete)
+                    .size(iconSize)
+                    .padding(iconPadding),
+                imageVector = Icons.Default.DeleteOutline,
+                contentDescription = "Delete",
 //            contentDescription = stringResource(R.string.delete),
-            tint = tint
-        )
+                tint = tint
+            )
 
-        Spacer(modifier = Modifier.width(spaceWidth))
+            Spacer(modifier = Modifier.width(spaceWidth))
 
-        Icon(
-            modifier = Modifier
-                .clip(clipShape)
-                .clickable(onClick = onAddPage)
-                .size(iconSize)
-                .padding(iconPadding),
-            imageVector = WrSdkIcons.linkPage,
-            contentDescription = "Link to page",
-            tint = tint
-        )
-
-        Spacer(modifier = Modifier.weight(1F))
+            Icon(
+                modifier = Modifier
+                    .clip(clipShape)
+                    .clickable(onClick = onAddPage)
+                    .size(iconSize)
+                    .padding(iconPadding),
+                imageVector = WrSdkIcons.linkPage,
+                contentDescription = "Link to page",
+                tint = tint
+            )
+        }
 
         Icon(
             modifier = Modifier
@@ -181,7 +188,7 @@ fun EditionScreen(
                 .size(iconSize)
                 .padding(iconPadding),
             imageVector = WrSdkIcons.close,
-            contentDescription = "List item",
+            contentDescription = "Close",
 //            contentDescription = stringResource(R.string.delete),
             tint = tint
         )

--- a/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/components/EditionScreen.kt
+++ b/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/components/EditionScreen.kt
@@ -37,6 +37,7 @@ fun EditionScreen(
     onCopy: () -> Unit = {},
     onCut: () -> Unit = {},
     onClose: () -> Unit = {},
+    onAddPage: () -> Unit = {},
 ) {
     val iconPadding = PaddingValues(vertical = 4.dp)
     val clipShape = MaterialTheme.shapes.medium
@@ -155,6 +156,19 @@ fun EditionScreen(
             imageVector = Icons.Default.DeleteOutline,
             contentDescription = "Delete",
 //            contentDescription = stringResource(R.string.delete),
+            tint = tint
+        )
+
+        Spacer(modifier = Modifier.width(spaceWidth))
+
+        Icon(
+            modifier = Modifier
+                .clip(clipShape)
+                .clickable(onClick = onAddPage)
+                .size(iconSize)
+                .padding(iconPadding),
+            imageVector = WrSdkIcons.linkPage,
+            contentDescription = "Link to page",
             tint = tint
         )
 

--- a/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/icons/WrSdkIcons.kt
+++ b/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/icons/WrSdkIcons.kt
@@ -8,6 +8,7 @@ import io.writeopia.ui.icons.all.ChevronDown
 import io.writeopia.ui.icons.all.ChevronRight
 import io.writeopia.ui.icons.all.ChevronUp
 import io.writeopia.ui.icons.all.Files
+import io.writeopia.ui.icons.all.Link
 import io.writeopia.ui.icons.all.SquareCheck
 import io.writeopia.ui.icons.all.WandSparkles
 
@@ -30,4 +31,6 @@ object WrSdkIcons {
     val check: ImageVector = Check
 
     val ai = WandSparkles
+
+    val linkPage: ImageVector = Link
 }

--- a/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/icons/all/Link.kt
+++ b/writeopia_ui/src/commonMain/kotlin/io/writeopia/ui/icons/all/Link.kt
@@ -1,0 +1,53 @@
+package io.writeopia.ui.icons.all
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+val Link: ImageVector
+    get() {
+        if (_Link != null) {
+            return _Link!!
+        }
+        ImageVector.Builder(
+            name = "Link",
+            defaultWidth = 24.dp,
+            defaultHeight = 24.dp,
+            viewportWidth = 24f,
+            viewportHeight = 24f
+        ).apply {
+            path(
+                stroke = SolidColor(Color(0xFF000000)),
+                strokeLineWidth = 2f,
+                strokeLineCap = StrokeCap.Round,
+                strokeLineJoin = StrokeJoin.Round
+            ) {
+                moveTo(10f, 13f)
+                arcToRelative(5f, 5f, 0f, isMoreThanHalf = false, isPositiveArc = false, 7.54f, 0.54f)
+                lineToRelative(3f, -3f)
+                arcToRelative(5f, 5f, 0f, isMoreThanHalf = false, isPositiveArc = false, -7.07f, -7.07f)
+                lineToRelative(-1.72f, 1.71f)
+            }
+            path(
+                stroke = SolidColor(Color(0xFF000000)),
+                strokeLineWidth = 2f,
+                strokeLineCap = StrokeCap.Round,
+                strokeLineJoin = StrokeJoin.Round
+            ) {
+                moveTo(14f, 11f)
+                arcToRelative(5f, 5f, 0f, isMoreThanHalf = false, isPositiveArc = false, -7.54f, -0.54f)
+                lineToRelative(-3f, 3f)
+                arcToRelative(5f, 5f, 0f, isMoreThanHalf = false, isPositiveArc = false, 7.07f, 7.07f)
+                lineToRelative(1.71f, -1.71f)
+            }
+        }.build().also { _Link = it }
+
+        return _Link!!
+    }
+
+@Suppress("ObjectPropertyName")
+private var _Link: ImageVector? = null


### PR DESCRIPTION
## General (fixes #429)

A new button has been added to the toolbar in the `EditionScreen.kt` file. This button calls the `NoteEditorViewModel::addPage` function.

The icon used is from Lucide: https://lucide.dev/icons/link.

The same icon has also been added to the Desktop as it provides the same functionality.

## Obs
- There's a bug related to incorrect behavior in the Android database due to missing implementations. This bug is currently out of scope for this task.
- The Android toolbar now has a scroll for its items (with the exception of the "Close" button). This new behavior is because the toolbar is running out of space. The commit with these changes is `2c6afa2ddc0fee89b7cda861b5beff127fa0cf0c`


## Video

https://github.com/user-attachments/assets/fea67ead-fc87-4095-8e6e-521884f530c4

