### PR TITLE
Feat/i18n de 424

### DIFF
--- a/writeopia_ui/src/commonMain/composeResources/values-de/strings.xml
+++ b/writeopia_ui/src/commonMain/composeResources/values-de/strings.xml
@@ -1,4 +1,4 @@
 <resources>
   <string name="title">Titel</string>
-  <string name="ai_generated">AI generiert</string>
+  <string name="ai_generated">KI-generiert</string>
 </resources>

--- a/writeopia_ui/src/commonMain/composeResources/values-de/strings.xml
+++ b/writeopia_ui/src/commonMain/composeResources/values-de/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+  <string name="title">Titel</string>
+  <string name="ai_generated">AI generiert</string>
+</resources>


### PR DESCRIPTION
#424 
feat(i18n): Add German translations (values-de)
Related to issue #424
What’s in this PR
Adds German localization resources under writeopia_ui/src/commonMain/composeResources/values-de/strings.xml.
Translated keys:
title → “Titel”
ai_generated → “KI-generiert”
Why
Adds German language support per the project’s i18n initiative, making the app more accessible to German-speaking users.
How to test
Android: Set emulator/device locale to German (de-DE) and launch the app.
Desktop: Set system language to German and run the desktop target.
iOS: Set the simulator to German and run the app.
Verify that:
Strings render in German where available.
Fallback language remains correct for any strings not yet translated.
Notes
No behavior changes or API changes.
If new string keys are added later, the values-de file should be updated accordingly.
Placeholders and punctuation are preserved; no formatting arguments were introduced in these keys.
Checklist
[x] Added values-de/strings.xml
[x] Verified XML formatting
[x] Confirmed keys match existing defaults (values/values-en)
[ ] CI passes
Screenshots
N/A
Future work
Translate additional strings as they are introduced.
Add more languages per issue #424.