### PR TITLE
Ignoring sync for summary in webapp

### DIFF
--- a/application/core/documents/src/commonMain/kotlin/io/writeopia/core/folders/api/DocumentsApi.kt
+++ b/application/core/documents/src/commonMain/kotlin/io/writeopia/core/folders/api/DocumentsApi.kt
@@ -427,6 +427,7 @@ class DocumentsApi(private val client: HttpClient, private val baseUrl: String) 
      * @param workspaceId The workspace ID
      * @param summaryTitle Optional custom title for the summary document
      * @param model Optional AI model override
+     * @param ignoreSyncCheck If true, skip sync validation (used by web clients without local storage)
      * @param token Authentication token
      * @return GenerateSummaryApiResult - Success with document, NeedsSync with unsynced docs, or Error
      */
@@ -436,11 +437,12 @@ class DocumentsApi(private val client: HttpClient, private val baseUrl: String) 
         workspaceId: String,
         summaryTitle: String?,
         model: String?,
+        ignoreSyncCheck: Boolean = false,
         token: String
     ): GenerateSummaryApiResult = try {
         val response = client.post("$baseUrl/api/docs/workspace/$workspaceId/document/generate-summary") {
             contentType(ContentType.Application.Json)
-            setBody(GenerateSummaryRequest(documents, targetFolderId, summaryTitle, model))
+            setBody(GenerateSummaryRequest(documents, targetFolderId, summaryTitle, model, ignoreSyncCheck))
             header(HttpHeaders.Authorization, "Bearer $token")
         }
 

--- a/application/core/documents/src/commonMain/kotlin/io/writeopia/core/folders/api/DocumentsApi.kt
+++ b/application/core/documents/src/commonMain/kotlin/io/writeopia/core/folders/api/DocumentsApi.kt
@@ -437,8 +437,8 @@ class DocumentsApi(private val client: HttpClient, private val baseUrl: String) 
         workspaceId: String,
         summaryTitle: String?,
         model: String?,
-        ignoreSyncCheck: Boolean = false,
-        token: String
+        token: String,
+        ignoreSyncCheck: Boolean = false
     ): GenerateSummaryApiResult = try {
         val response = client.post("$baseUrl/api/docs/workspace/$workspaceId/document/generate-summary") {
             contentType(ContentType.Application.Json)

--- a/application/features/note_menu/src/commonMain/kotlin/io/writeopia/notemenu/viewmodel/onlybe/OnlyBackendChooseNoteKmpViewModel.kt
+++ b/application/features/note_menu/src/commonMain/kotlin/io/writeopia/notemenu/viewmodel/onlybe/OnlyBackendChooseNoteKmpViewModel.kt
@@ -408,8 +408,8 @@ internal class OnlyBackendChooseNoteKmpViewModel(
                     workspaceId = workspace.id,
                     summaryTitle = null,
                     model = null,
-                    ignoreSyncCheck = true,
-                    token = token
+                    token = token,
+                    ignoreSyncCheck = true
                 )
 
                 when (result) {

--- a/application/features/note_menu/src/commonMain/kotlin/io/writeopia/notemenu/viewmodel/onlybe/OnlyBackendChooseNoteKmpViewModel.kt
+++ b/application/features/note_menu/src/commonMain/kotlin/io/writeopia/notemenu/viewmodel/onlybe/OnlyBackendChooseNoteKmpViewModel.kt
@@ -2,6 +2,8 @@ package io.writeopia.notemenu.viewmodel.onlybe
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import io.writeopia.ai.task.AiTaskManager
+import io.writeopia.ai.task.AiTaskType
 import io.writeopia.auth.core.manager.AuthRepository
 import io.writeopia.common.utils.NotesNavigation
 import io.writeopia.common.utils.NotesNavigationType
@@ -22,6 +24,7 @@ import io.writeopia.notemenu.viewmodel.UserState
 import io.writeopia.onboarding.OnboardingState
 import io.writeopia.sdk.models.document.Folder
 import io.writeopia.sdk.models.document.MenuItem
+import io.writeopia.sdk.models.id.GenerateId
 import io.writeopia.sdk.models.files.ExternalFile
 import io.writeopia.sdk.models.sorting.OrderBy
 import io.writeopia.sdk.models.user.WriteopiaUser
@@ -376,12 +379,14 @@ internal class OnlyBackendChooseNoteKmpViewModel(
         if (!hasSelectedNotes.value) return
 
         val selectedIds = selectedNotes.value.toList()
+        val documentCount = selectedIds.size
         hideAiOptions()
         clearSelection()
 
         viewModelScope.launch(Dispatchers.Default) {
             val token = authRepository.getAuthToken() ?: return@launch
             val workspace = authRepository.getWorkspace() ?: return@launch
+            val taskId = GenerateId.generate()
 
             val targetFolderId = when (notesNavigation.navigationType) {
                 NotesNavigationType.FOLDER -> notesNavigation.id
@@ -392,28 +397,36 @@ internal class OnlyBackendChooseNoteKmpViewModel(
                 DocumentSyncInfo(documentId = documentId, lastSyncedAt = null)
             }
 
-            val result = documentsApi.generateSummary(
-                documents = documents,
-                targetFolderId = targetFolderId,
-                workspaceId = workspace.id,
-                summaryTitle = null,
-                model = null,
-                token = token
-            )
+            AiTaskManager.singleton().enqueueTask(
+                id = taskId,
+                type = AiTaskType.SUMMARIZATION,
+                description = "Summarizing $documentCount document${if (documentCount > 1) "s" else ""}"
+            ) {
+                val result = documentsApi.generateSummary(
+                    documents = documents,
+                    targetFolderId = targetFolderId,
+                    workspaceId = workspace.id,
+                    summaryTitle = null,
+                    model = null,
+                    ignoreSyncCheck = true,
+                    token = token
+                )
 
-            when (result) {
-                is GenerateSummaryApiResult.Success -> {
-                    // Refresh the folder contents to show the new summary document
-                    loadFolderContents()
-                }
-                is GenerateSummaryApiResult.NeedsSync -> {
-                    // Documents need sync - but user said not to sync, so just log/ignore
-                }
-                is GenerateSummaryApiResult.GenAiUnavailable -> {
-                    // GenAI is not available
-                }
-                is GenerateSummaryApiResult.Error -> {
-                    // Handle error
+                when (result) {
+                    is GenerateSummaryApiResult.Success -> {
+                        // Refresh the folder contents to show the new summary document
+                        loadFolderContents()
+                        Result.success(Unit)
+                    }
+                    is GenerateSummaryApiResult.NeedsSync -> {
+                        Result.failure(Exception("Documents need sync"))
+                    }
+                    is GenerateSummaryApiResult.GenAiUnavailable -> {
+                        Result.failure(Exception("GenAI is not available"))
+                    }
+                    is GenerateSummaryApiResult.Error -> {
+                        Result.failure(Exception(result.message ?: "Unknown error"))
+                    }
                 }
             }
         }

--- a/backend/documents/documents/src/main/java/io/writeopia/api/documents/documents/DocumentsService.kt
+++ b/backend/documents/documents/src/main/java/io/writeopia/api/documents/documents/DocumentsService.kt
@@ -649,6 +649,7 @@ object DocumentsService {
         workspaceId: String,
         summaryTitle: String?,
         model: String?,
+        ignoreSyncCheck: Boolean,
         genAiService: GenAiService,
         writeopiaDb: WriteopiaDbBackend
     ): GenerateSummaryResult {
@@ -676,7 +677,7 @@ object DocumentsService {
             }
         }
 
-        // Fetch all documents and check sync status
+        // Fetch all documents and check sync status (unless ignoreSyncCheck is true)
         val unsyncedDocuments = mutableListOf<UnsyncedDocumentInfo>()
         val documentsToProcess = mutableListOf<Document>()
 
@@ -686,27 +687,32 @@ object DocumentsService {
                 return GenerateSummaryResult.NotFound("Document not found: ${docSyncInfo.documentId}")
             }
 
-            // Check sync status: compare client's lastSyncedAt with server's lastSyncedAt
-            // They must match for the document to be considered synced
-            val serverLastSyncedAt = document.lastSyncedAt?.toEpochMilliseconds()
-            val clientLastSyncedAt = docSyncInfo.lastSyncedAt
-
-            // Document is synced if both lastSyncedAt values match
-            val isSynced = serverLastSyncedAt != null &&
-                           clientLastSyncedAt != null &&
-                           serverLastSyncedAt == clientLastSyncedAt
-
-            if (!isSynced) {
-                unsyncedDocuments.add(
-                    UnsyncedDocumentInfo(
-                        documentId = document.id,
-                        documentTitle = document.title,
-                        lastUpdatedAt = document.lastUpdatedAt.toEpochMilliseconds(),
-                        lastSyncedAt = serverLastSyncedAt
-                    )
-                )
-            } else {
+            if (ignoreSyncCheck) {
+                // Web clients skip sync check - they always use server version
                 documentsToProcess.add(document)
+            } else {
+                // Check sync status: compare client's lastSyncedAt with server's lastSyncedAt
+                // They must match for the document to be considered synced
+                val serverLastSyncedAt = document.lastSyncedAt?.toEpochMilliseconds()
+                val clientLastSyncedAt = docSyncInfo.lastSyncedAt
+
+                // Document is synced if both lastSyncedAt values match
+                val isSynced = serverLastSyncedAt != null &&
+                               clientLastSyncedAt != null &&
+                               serverLastSyncedAt == clientLastSyncedAt
+
+                if (!isSynced) {
+                    unsyncedDocuments.add(
+                        UnsyncedDocumentInfo(
+                            documentId = document.id,
+                            documentTitle = document.title,
+                            lastUpdatedAt = document.lastUpdatedAt.toEpochMilliseconds(),
+                            lastSyncedAt = serverLastSyncedAt
+                        )
+                    )
+                } else {
+                    documentsToProcess.add(document)
+                }
             }
         }
 

--- a/backend/documents/documents/src/main/java/io/writeopia/api/documents/routing/DocumentsRouting.kt
+++ b/backend/documents/documents/src/main/java/io/writeopia/api/documents/routing/DocumentsRouting.kt
@@ -747,6 +747,7 @@ fun Routing.documentsRoute(
                         workspaceId = workspaceId,
                         summaryTitle = request.summaryTitle,
                         model = request.model,
+                        ignoreSyncCheck = request.ignoreSyncCheck,
                         genAiService = genAiService,
                         writeopiaDb = writeopiaDb
                     )

--- a/plugins/writeopia_serialization/src/commonMain/kotlin/io/writeopia/sdk/serialization/request/GenerateSummaryRequest.kt
+++ b/plugins/writeopia_serialization/src/commonMain/kotlin/io/writeopia/sdk/serialization/request/GenerateSummaryRequest.kt
@@ -7,7 +7,8 @@ data class GenerateSummaryRequest(
     val documents: List<DocumentSyncInfo>,
     val targetFolderId: String,
     val summaryTitle: String? = null,
-    val model: String? = null
+    val model: String? = null,
+    val ignoreSyncCheck: Boolean = false
 )
 
 @Serializable


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to generate AI summaries using the latest server document versions without performing synchronization checks.
  * AI summarization now runs as a tracked task, with progress metadata and clearer success or failure reporting.
  * Folder contents refresh automatically after successful summarization.

* **Bug Fixes**
  * Improved handling of synchronization, service availability, and API errors during summarization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->