### PR TITLE
Creating tutorials only in backend

### DIFF
--- a/application/core/auth_core/src/commonMain/kotlin/io/writeopia/auth/core/data/WorkspaceApi.kt
+++ b/application/core/auth_core/src/commonMain/kotlin/io/writeopia/auth/core/data/WorkspaceApi.kt
@@ -262,5 +262,4 @@ class WorkspaceApi(private val client: HttpClient, private val baseUrl: String) 
         e.printStackTrace()
         ResultData.Error(e)
     }
-
 }

--- a/application/core/auth_core/src/commonMain/kotlin/io/writeopia/auth/core/data/WorkspaceApi.kt
+++ b/application/core/auth_core/src/commonMain/kotlin/io/writeopia/auth/core/data/WorkspaceApi.kt
@@ -263,21 +263,4 @@ class WorkspaceApi(private val client: HttpClient, private val baseUrl: String) 
         ResultData.Error(e)
     }
 
-    suspend fun initializeTutorials(
-        workspaceId: String,
-        token: String
-    ): ResultData<Unit> = try {
-        val response = client.post("$baseUrl/api/docs/workspace/$workspaceId/tutorials/initialize") {
-            header(HttpHeaders.Authorization, "Bearer $token")
-        }
-
-        if (response.status.isSuccess()) {
-            ResultData.Complete(Unit)
-        } else {
-            ResultData.Error()
-        }
-    } catch (e: Exception) {
-        e.printStackTrace()
-        ResultData.Error(e)
-    }
 }

--- a/application/features/account/src/commonMain/kotlin/io/writeopia/account/navigation/AccountNavigation.kt
+++ b/application/features/account/src/commonMain/kotlin/io/writeopia/account/navigation/AccountNavigation.kt
@@ -614,6 +614,8 @@ fun NavGraphBuilder.accountMenuNavigation(
                 modifier = Modifier.background(WriteopiaTheme.colorScheme.lightBackground)
                     .padding(paddingValues),
                 isLoggedInState = accountMenuViewModel.isLoggedIn,
+                workspacesState = accountMenuViewModel.availableWorkspaces,
+                exportWorkspaceState = accountMenuViewModel.exportWorkspaceState,
                 goToRegister = navigateToAuthMenu,
                 changeAccount = navigateToAuthMenu,
                 changeWorkspace = {
@@ -621,6 +623,10 @@ fun NavGraphBuilder.accountMenuNavigation(
                         navigateToChooseWorkspace()
                     }
                 },
+                exportWorkspace = { workspaceId ->
+                    accountMenuViewModel.exportWorkspace(workspaceId)
+                },
+                resetExportState = accountMenuViewModel::resetExportState,
                 resetPassword = resetPassword,
                 logout = {
                     accountMenuViewModel.logout {

--- a/application/features/account/src/commonMain/kotlin/io/writeopia/account/ui/SettingsAccountScreen.kt
+++ b/application/features/account/src/commonMain/kotlin/io/writeopia/account/ui/SettingsAccountScreen.kt
@@ -34,20 +34,26 @@ import io.writeopia.common.utils.icons.WrIcons
 import io.writeopia.resources.WrStrings
 import io.writeopia.sdk.models.utils.ResultData
 import io.writeopia.sdk.models.utils.toBoolean
+import io.writeopia.sdk.models.workspace.Workspace
 import io.writeopia.theme.WriteopiaTheme
 import kotlinx.coroutines.flow.StateFlow
 
 @Composable
 fun SettingsAccountScreen(
     isLoggedInState: StateFlow<ResultData<Boolean>>,
+    workspacesState: StateFlow<ResultData<List<Workspace>>>,
+    exportWorkspaceState: StateFlow<ResultData<Unit>>,
     goToRegister: () -> Unit,
     changeAccount: () -> Unit,
     changeWorkspace: () -> Unit,
+    exportWorkspace: (String) -> Unit,
+    resetExportState: () -> Unit,
     resetPassword: () -> Unit,
     logout: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var showLogoutDialog by remember { mutableStateOf(false) }
+    var showExportDialog by remember { mutableStateOf(false) }
 
     Column(
         modifier = modifier.fillMaxSize()
@@ -84,6 +90,14 @@ fun SettingsAccountScreen(
                 title = WrStrings.changeWorkspace(),
                 icon = WrIcons.group,
                 onClick = changeWorkspace
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            AccountMenuItem(
+                title = WrStrings.exportWorkspace(),
+                icon = WrIcons.download,
+                onClick = { showExportDialog = true }
             )
 
             Spacer(modifier = Modifier.height(8.dp))
@@ -130,6 +144,18 @@ fun SettingsAccountScreen(
                 TextButton(onClick = { showLogoutDialog = false }) {
                     Text(text = WrStrings.cancel())
                 }
+            }
+        )
+    }
+
+    if (showExportDialog) {
+        ExportWorkspaceDialog(
+            workspacesState = workspacesState,
+            exportState = exportWorkspaceState,
+            onExport = exportWorkspace,
+            onDismiss = {
+                showExportDialog = false
+                resetExportState()
             }
         )
     }

--- a/application/features/auth/src/commonMain/kotlin/io/writeopia/auth/workspace/ChooseWorkspaceViewModel.kt
+++ b/application/features/auth/src/commonMain/kotlin/io/writeopia/auth/workspace/ChooseWorkspaceViewModel.kt
@@ -78,14 +78,9 @@ class ChooseWorkspaceViewModel(
                 val isOnlineWorkspace = workspaceId != "disconnected_user"
 
                 val tutorialsInitialized = if (isOnlineWorkspace) {
-                    // For online workspaces, create tutorials on the backend
-                    val token = authRepository.getAuthToken()
-                    if (token != null) {
-                        val result = workspaceApi.initializeTutorials(workspaceId, token)
-                        result is ResultData.Complete
-                    } else {
-                        false
-                    }
+                    // For online workspaces, tutorials are initialized on the backend
+                    // when the workspace is created
+                    true
                 } else {
                     // For offline mode, create tutorials locally
                     val now = Clock.System.now()

--- a/backend/core/auth/src/main/java/io/writeopia/api/core/auth/routing/WorkspaceRouting.kt
+++ b/backend/core/auth/src/main/java/io/writeopia/api/core/auth/routing/WorkspaceRouting.kt
@@ -17,7 +17,6 @@ import io.writeopia.api.core.auth.repository.getUserRoleInWorkspace
 import io.writeopia.api.core.auth.repository.listWorkspaces
 import io.writeopia.api.core.auth.repository.searchUsersByEmail
 import io.writeopia.api.core.auth.service.WorkspaceService
-import io.writeopia.api.documents.documents.TutorialsService
 import io.writeopia.api.core.auth.utils.runIfAdmin
 import io.writeopia.app.dto.PaginatedUserSearchResponse
 import io.writeopia.app.dto.PaginatedWorkspaceUsersResponse
@@ -39,7 +38,8 @@ private val logger = LoggerFactory.getLogger("WorkspaceRouting")
 fun Routing.workspaceRoute(
     apiKey: String?,
     writeopiaDb: WriteopiaDbBackend,
-    debugMode: Boolean = false
+    debugMode: Boolean = false,
+    onWorkspaceCreated: (suspend (userId: String, workspaceId: String) -> Unit)? = null
 ) {
     get("/api/workspace") {
         val providedKey = if (debugMode) "debug" else call.request.header("X-Admin-Key")
@@ -104,11 +104,7 @@ fun Routing.workspaceRoute(
             )
 
             // Initialize tutorial documents for the new workspace
-            TutorialsService.initializeTutorialsForUser(
-                userId = userId,
-                workspaceId = workspaceId,
-                writeopiaDb = writeopiaDb
-            )
+            onWorkspaceCreated?.invoke(userId, workspaceId)
 
             call.respond(HttpStatusCode.Created, ServerResponse("Workspace created"))
         }

--- a/backend/core/auth/src/main/java/io/writeopia/api/core/auth/routing/WorkspaceRouting.kt
+++ b/backend/core/auth/src/main/java/io/writeopia/api/core/auth/routing/WorkspaceRouting.kt
@@ -17,6 +17,7 @@ import io.writeopia.api.core.auth.repository.getUserRoleInWorkspace
 import io.writeopia.api.core.auth.repository.listWorkspaces
 import io.writeopia.api.core.auth.repository.searchUsersByEmail
 import io.writeopia.api.core.auth.service.WorkspaceService
+import io.writeopia.api.documents.documents.TutorialsService
 import io.writeopia.api.core.auth.utils.runIfAdmin
 import io.writeopia.app.dto.PaginatedUserSearchResponse
 import io.writeopia.app.dto.PaginatedWorkspaceUsersResponse
@@ -99,6 +100,13 @@ fun Routing.workspaceRoute(
                 userId = userId,
                 workspaceId = workspaceId,
                 role = Role.ADMIN.value,
+                writeopiaDb = writeopiaDb
+            )
+
+            // Initialize tutorial documents for the new workspace
+            TutorialsService.initializeTutorialsForUser(
+                userId = userId,
+                workspaceId = workspaceId,
                 writeopiaDb = writeopiaDb
             )
 

--- a/backend/core/auth/src/main/java/io/writeopia/api/core/auth/routing/WorkspaceRouting.kt
+++ b/backend/core/auth/src/main/java/io/writeopia/api/core/auth/routing/WorkspaceRouting.kt
@@ -94,17 +94,24 @@ fun Routing.workspaceRoute(
             val userId = getUserId() ?: ""
             val (workspaceName) = request
 
+            // Create workspace and add user as admin atomically
             val workspaceId = GenerateId.generate()
-            WorkspaceService.createWorkspace(workspaceId, workspaceName, writeopiaDb)
-            WorkspaceService.addUserToWorkspaceByUserId(
-                userId = userId,
+            WorkspaceService.createWorkspaceWithOwner(
                 workspaceId = workspaceId,
-                role = Role.ADMIN.value,
+                workspaceName = workspaceName,
+                userId = userId,
                 writeopiaDb = writeopiaDb
             )
 
-            // Initialize tutorial documents for the new workspace
-            onWorkspaceCreated?.invoke(userId, workspaceId)
+            // Initialize tutorial documents for the new workspace.
+            // This is idempotent - if it fails, users can retry via
+            // POST /api/docs/workspace/{workspaceId}/tutorials/initialize
+            try {
+                onWorkspaceCreated?.invoke(userId, workspaceId)
+            } catch (e: Exception) {
+                logger.warn("Failed to initialize tutorials for workspace $workspaceId: ${e.message}")
+                // Continue - workspace is created, tutorials can be initialized later
+            }
 
             call.respond(HttpStatusCode.Created, ServerResponse("Workspace created"))
         }

--- a/backend/core/auth/src/main/java/io/writeopia/api/core/auth/service/WorkspaceService.kt
+++ b/backend/core/auth/src/main/java/io/writeopia/api/core/auth/service/WorkspaceService.kt
@@ -21,6 +21,7 @@ import io.writeopia.api.core.auth.repository.removeUserFromWorkspace
 import io.writeopia.connection.logger
 import io.writeopia.models.user.PaginatedWorkspaceUsers
 import io.writeopia.models.user.WorkspaceUser
+import io.writeopia.sdk.models.workspace.Role
 import io.writeopia.sdk.models.workspace.Workspace
 import io.writeopia.sql.WriteopiaDbBackend
 import kotlin.time.ExperimentalTime
@@ -93,6 +94,34 @@ object WorkspaceService {
                 role = ""
             )
         )
+    }
+
+    /**
+     * Creates a workspace and adds the user as admin in a single transaction.
+     * This ensures atomicity - either both operations succeed or neither does.
+     *
+     * @return the workspace ID if successful
+     */
+    fun createWorkspaceWithOwner(
+        workspaceId: String,
+        workspaceName: String,
+        userId: String,
+        writeopiaDb: WriteopiaDbBackend
+    ): String {
+        writeopiaDb.transaction {
+            writeopiaDb.insertWorkspace(
+                Workspace(
+                    id = workspaceId,
+                    userId = "",
+                    name = workspaceName,
+                    lastSync = Instant.DISTANT_PAST,
+                    selected = false,
+                    role = ""
+                )
+            )
+            writeopiaDb.insertUserInWorkspace(workspaceId, userId, Role.ADMIN.value)
+        }
+        return workspaceId
     }
 
     fun addUserToWorkspaceAdmin(

--- a/backend/documents/documents/src/main/java/io/writeopia/api/documents/documents/TutorialsService.kt
+++ b/backend/documents/documents/src/main/java/io/writeopia/api/documents/documents/TutorialsService.kt
@@ -2,6 +2,8 @@
 
 package io.writeopia.api.documents.documents
 
+import io.writeopia.sdk.models.document.Document
+import io.writeopia.sdk.models.id.GenerateId
 import io.writeopia.sdk.serialization.data.DocumentApi
 import io.writeopia.sdk.serialization.extensions.toModel
 import io.writeopia.sdk.serialization.json.writeopiaJson
@@ -40,12 +42,13 @@ object TutorialsService {
 
         val now = Clock.System.now()
 
-        // Create all tutorial documents
+        // Create all tutorial documents with unique IDs for this workspace
         Tutorials.allTutorialsDocuments()
             .map { documentAsJson ->
                 json.decodeFromString<DocumentApi>(documentAsJson)
                     .toModel()
             }
+            .map { document -> regenerateIds(document) }
             .forEach { document ->
                 val documentWithWorkspace = document.copy(
                     workspaceId = workspaceId,
@@ -71,5 +74,23 @@ object TutorialsService {
         )
 
         return true
+    }
+
+    /**
+     * Regenerates all IDs in a document to make it unique.
+     * This includes the document ID and all story step IDs in the content.
+     */
+    private fun regenerateIds(document: Document): Document {
+        val newContent = document.content.mapValues { (_, storyStep) ->
+            storyStep.copy(
+                id = GenerateId.generate(),
+                localId = GenerateId.generate()
+            )
+        }
+
+        return document.copy(
+            id = GenerateId.generate(),
+            content = newContent
+        )
     }
 }

--- a/backend/gateway/src/main/kotlin/io/writeopia/api/geteway/Routing.kt
+++ b/backend/gateway/src/main/kotlin/io/writeopia/api/geteway/Routing.kt
@@ -10,6 +10,7 @@ import io.writeopia.api.core.auth.routing.authRoute
 import io.writeopia.api.core.auth.routing.cookieAuthRoute
 import io.writeopia.api.core.auth.routing.passwordResetRoute
 import io.writeopia.api.core.auth.routing.workspaceRoute
+import io.writeopia.api.documents.documents.TutorialsService
 import io.writeopia.api.documents.routing.documentsRoute
 import io.writeopia.api.genai.service.GenAiService
 import io.writeopia.connection.logger
@@ -33,7 +34,18 @@ fun Application.configureRouting(
             // Web-specific auth routes using HttpOnly cookies
             cookieAuthRoute(writeopiaDb, debugMode)
 
-            workspaceRoute(adminKey, writeopiaDb, debugMode)
+            workspaceRoute(
+                apiKey = adminKey,
+                writeopiaDb = writeopiaDb,
+                debugMode = debugMode,
+                onWorkspaceCreated = { userId, workspaceId ->
+                    TutorialsService.initializeTutorialsForUser(
+                        userId = userId,
+                        workspaceId = workspaceId,
+                        writeopiaDb = writeopiaDb
+                    )
+                }
+            )
 
             passwordResetRoute(writeopiaDb)
 

--- a/backend/gateway/src/test/kotlin/io/writeopia/api/gateway/WorkspaceTutorialsTest.kt
+++ b/backend/gateway/src/test/kotlin/io/writeopia/api/gateway/WorkspaceTutorialsTest.kt
@@ -1,0 +1,270 @@
+package io.writeopia.api.gateway
+
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.testing.testApplication
+import io.writeopia.api.core.auth.repository.deleteUserByEmail
+import io.writeopia.api.geteway.configurePersistence
+import io.writeopia.api.geteway.module
+import io.writeopia.app.requests.CreateWorkspaceRequest
+import io.writeopia.sdk.serialization.data.WorkspaceApi
+import io.writeopia.sdk.serialization.data.auth.AuthResponse
+import io.writeopia.sdk.serialization.data.auth.LoginRequest
+import io.writeopia.sdk.serialization.data.auth.RegisterRequest
+import kotlin.random.Random
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class WorkspaceTutorialsTest {
+    private val db = configurePersistence()
+
+    private val testEmails = mutableListOf<String>()
+
+    @BeforeTest
+    fun setUp() {
+        testEmails.clear()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        testEmails.forEach { email ->
+            db.deleteUserByEmail(email)
+        }
+    }
+
+    @Test
+    fun `tutorials should be created when a new workspace is created`() = testApplication {
+        application {
+            module(db, debugMode = true)
+        }
+
+        val client = defaultClient()
+        val email = "tutorials_create_${Random.nextInt(10000)}@test.com"
+        val password = "testpassword123&"
+        testEmails.add(email)
+
+        // Register a user first (this creates an initial workspace without tutorials)
+        val registerResponse = client.post("/api/auth/register") {
+            contentType(ContentType.Application.Json)
+            setBody(
+                RegisterRequest(
+                    workspaceName = "Initial Workspace",
+                    name = "Test User",
+                    email = email,
+                    password = password,
+                )
+            )
+        }
+
+        assertEquals(HttpStatusCode.Created, registerResponse.status)
+
+        // Login to get access token
+        val loginResponse = client.post("/api/auth/login") {
+            contentType(ContentType.Application.Json)
+            setBody(LoginRequest(email, password))
+        }
+
+        assertEquals(HttpStatusCode.OK, loginResponse.status)
+        val authResponse = loginResponse.body<AuthResponse>()
+        val accessToken = authResponse.accessToken!!
+
+        // Create a NEW workspace - this should initialize tutorials
+        val newWorkspaceName = "New Workspace With Tutorials"
+        val createWorkspaceResponse = client.post("/api/workspace/create") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer $accessToken")
+            setBody(CreateWorkspaceRequest(newWorkspaceName))
+        }
+
+        assertEquals(HttpStatusCode.Created, createWorkspaceResponse.status)
+
+        // Get all workspaces for the user (admin endpoint)
+        val getWorkspacesResponse = client.get("/api/workspace/user/email/$email") {
+            contentType(ContentType.Application.Json)
+        }
+
+        assertEquals(HttpStatusCode.OK, getWorkspacesResponse.status)
+        val workspaces = getWorkspacesResponse.body<List<WorkspaceApi>>()
+
+        // Find the newly created workspace
+        val newWorkspace = workspaces.find { it.name == newWorkspaceName }
+        assertTrue(newWorkspace != null, "New workspace should exist. Found workspaces: ${workspaces.map { it.name }}")
+
+        // The new workspace should have tutorial documents (5 tutorials)
+        // Tutorials: welcomeTutorial, aiTutorial, savingNotesTutorial, commandsTutorial, videoTutorial
+        assertEquals(5, newWorkspace.documentCount, "New workspace should have 5 tutorial documents")
+    }
+
+    @Test
+    fun `tutorials should only be created once per workspace per user`() = testApplication {
+        application {
+            module(db, debugMode = true)
+        }
+
+        val client = defaultClient()
+        val email = "tutorials_idempotent_${Random.nextInt(10000)}@test.com"
+        val password = "testpassword123&"
+        testEmails.add(email)
+
+        // Register a user
+        val registerResponse = client.post("/api/auth/register") {
+            contentType(ContentType.Application.Json)
+            setBody(
+                RegisterRequest(
+                    workspaceName = "Initial Workspace",
+                    name = "Test User",
+                    email = email,
+                    password = password,
+                )
+            )
+        }
+
+        assertEquals(HttpStatusCode.Created, registerResponse.status)
+
+        // Login to get access token
+        val loginResponse = client.post("/api/auth/login") {
+            contentType(ContentType.Application.Json)
+            setBody(LoginRequest(email, password))
+        }
+
+        assertEquals(HttpStatusCode.OK, loginResponse.status)
+        val authResponse = loginResponse.body<AuthResponse>()
+        val accessToken = authResponse.accessToken!!
+
+        // Create a new workspace
+        val workspaceName = "Workspace For Idempotent Test"
+        val createResponse1 = client.post("/api/workspace/create") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer $accessToken")
+            setBody(CreateWorkspaceRequest(workspaceName))
+        }
+
+        assertEquals(HttpStatusCode.Created, createResponse1.status)
+
+        // Get the workspace and check document count
+        val getWorkspacesResponse1 = client.get("/api/workspace/user/email/$email") {
+            contentType(ContentType.Application.Json)
+        }
+
+        val workspaces1 = getWorkspacesResponse1.body<List<WorkspaceApi>>()
+        val workspace1 = workspaces1.find { it.name == workspaceName }
+        assertTrue(workspace1 != null, "Workspace should exist")
+        val initialDocCount = workspace1.documentCount
+
+        // Manually call the tutorials initialization endpoint again
+        // This should not create duplicate tutorials
+        val initTutorialsResponse = client.post("/api/docs/workspace/${workspace1.id}/tutorials/initialize") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer $accessToken")
+        }
+
+        assertEquals(HttpStatusCode.OK, initTutorialsResponse.status)
+
+        // Get the workspace again and verify document count hasn't changed
+        val getWorkspacesResponse2 = client.get("/api/workspace/user/email/$email") {
+            contentType(ContentType.Application.Json)
+        }
+
+        val workspaces2 = getWorkspacesResponse2.body<List<WorkspaceApi>>()
+        val workspace2 = workspaces2.find { it.name == workspaceName }
+        assertTrue(workspace2 != null, "Workspace should still exist")
+
+        assertEquals(
+            initialDocCount,
+            workspace2.documentCount,
+            "Document count should remain the same after re-initialization"
+        )
+    }
+
+    @Test
+    fun `multiple workspaces created by same user should each have their own tutorials`() = testApplication {
+        application {
+            module(db, debugMode = true)
+        }
+
+        val client = defaultClient()
+        val email = "tutorials_multiple_${Random.nextInt(10000)}@test.com"
+        val password = "testpassword123&"
+        testEmails.add(email)
+
+        // Register a user
+        val registerResponse = client.post("/api/auth/register") {
+            contentType(ContentType.Application.Json)
+            setBody(
+                RegisterRequest(
+                    workspaceName = "Initial Workspace",
+                    name = "Test User",
+                    email = email,
+                    password = password,
+                )
+            )
+        }
+
+        assertEquals(HttpStatusCode.Created, registerResponse.status)
+
+        // Login to get access token
+        val loginResponse = client.post("/api/auth/login") {
+            contentType(ContentType.Application.Json)
+            setBody(LoginRequest(email, password))
+        }
+
+        assertEquals(HttpStatusCode.OK, loginResponse.status)
+        val authResponse = loginResponse.body<AuthResponse>()
+        val accessToken = authResponse.accessToken!!
+
+        // Create first new workspace
+        val workspace1Name = "First New Workspace"
+        val createResponse1 = client.post("/api/workspace/create") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer $accessToken")
+            setBody(CreateWorkspaceRequest(workspace1Name))
+        }
+
+        assertEquals(HttpStatusCode.Created, createResponse1.status)
+
+        // Create second new workspace
+        val workspace2Name = "Second New Workspace"
+        val createResponse2 = client.post("/api/workspace/create") {
+            contentType(ContentType.Application.Json)
+            header(HttpHeaders.Authorization, "Bearer $accessToken")
+            setBody(CreateWorkspaceRequest(workspace2Name))
+        }
+
+        assertEquals(HttpStatusCode.Created, createResponse2.status)
+
+        // Get all workspaces
+        val getWorkspacesResponse = client.get("/api/workspace/user/email/$email") {
+            contentType(ContentType.Application.Json)
+        }
+
+        assertEquals(HttpStatusCode.OK, getWorkspacesResponse.status)
+        val workspaces = getWorkspacesResponse.body<List<WorkspaceApi>>()
+
+        // Find both new workspaces
+        val newWorkspace1 = workspaces.find { it.name == workspace1Name }
+        val newWorkspace2 = workspaces.find { it.name == workspace2Name }
+
+        assertTrue(newWorkspace1 != null, "First new workspace should exist")
+        assertTrue(newWorkspace2 != null, "Second new workspace should exist")
+
+        // Both workspaces should have 5 tutorials each
+        assertEquals(5, newWorkspace1.documentCount, "First workspace should have 5 tutorials")
+        assertEquals(5, newWorkspace2.documentCount, "Second workspace should have 5 tutorials")
+
+        // They should have different IDs
+        assertTrue(
+            newWorkspace1.id != newWorkspace2.id,
+            "Workspaces should have different IDs"
+        )
+    }
+}

--- a/docker/postgres/init.sql
+++ b/docker/postgres/init.sql
@@ -109,6 +109,14 @@ CREATE TABLE sync_event (
   user_id TEXT NOT NULL
 );
 
+CREATE TABLE workspace_tutorial_status (
+  workspace_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  tutorials_created INTEGER NOT NULL DEFAULT 0,
+  created_at BIGINT NOT NULL,
+  PRIMARY KEY(workspace_id, user_id)
+);
+
 -- Indexes for common query patterns
 CREATE INDEX idx_document_workspace_id ON document_entity(workspace_id);
 CREATE INDEX idx_document_parent_id ON document_entity(parent_document_id);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Export Workspace” option to account settings for logged-in users.
  * Added an export dialog with progress handling and dismissal support.

* **Improvements**
  * New workspaces now receive tutorial content automatically during creation.
  * Tutorial content is generated independently for each workspace.
  * Workspace creation now assigns ownership consistently.
  * Offline workspace tutorial creation remains supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->