### PR TITLE
Ai hub not as default

### DIFF
--- a/application/features/search/src/commonMain/kotlin/io/writeopia/features/search/api/SearchApi.kt
+++ b/application/features/search/src/commonMain/kotlin/io/writeopia/features/search/api/SearchApi.kt
@@ -12,9 +12,11 @@ import io.writeopia.sdk.serialization.extensions.toModel
 
 class SearchApi(private val client: HttpClient, private val baseUrl: String) {
 
-    suspend fun searchApi(query: String): List<Document> = try {
-        val url = "$baseUrl/api/document/search?q=\"$query\""
-        val request = client.get(url) {
+    suspend fun searchApi(query: String, workspaceId: String): List<Document> = try {
+        val request = client.get("$baseUrl/api/docs/workspace/$workspaceId/document/search") {
+            url {
+                parameters.append("q", query)
+            }
             contentType(ContentType.Application.Json)
         }
 

--- a/application/features/search/src/commonMain/kotlin/io/writeopia/features/search/repository/SearchRepository.kt
+++ b/application/features/search/src/commonMain/kotlin/io/writeopia/features/search/repository/SearchRepository.kt
@@ -51,11 +51,17 @@ class SearchRepository(
         }
     }
 
-    fun searchNotesAndFoldersRemotely(query: String): Flow<List<SearchItem>> = flow {
-//            println("triggering documentsApiFlow")
-//            emit(emptyList())
-//            println("calling api")
-        emit(searchApi.searchApi(query).toSearchItems())
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun searchNotesAndFoldersRemotely(query: String): Flow<List<SearchItem>> {
+        if (query.isEmpty()) {
+            return flow { emit(emptyList()) }
+        }
+
+        return authRepository.listenForWorkspace().flatMapLatest { workspace ->
+            flow {
+                emit(searchApi.searchApi(query, workspace.id).toSearchItems())
+            }
+        }
     }
 
     private suspend fun getNotesAndFolders(workspaceId: String): List<SearchItem> {

--- a/backend/core/connection/src/main/java/io/writeopia/connection/Urls.kt
+++ b/backend/core/connection/src/main/java/io/writeopia/connection/Urls.kt
@@ -1,5 +1,5 @@
 package io.writeopia.connection
 
 object Urls {
-    const val AI_HUB = "http://localhost:8000"
+    val AI_HUB: String? = System.getenv("WRITEOPIA_AI_HUB_URL")
 }

--- a/backend/documents/documents/src/main/java/io/writeopia/api/documents/documents/DocumentsService.kt
+++ b/backend/documents/documents/src/main/java/io/writeopia/api/documents/documents/DocumentsService.kt
@@ -467,12 +467,14 @@ object DocumentsService {
             .map { ensureTitleInSync(it) }
     }
 
-    private suspend fun sendToAiHub(documents: List<Document>, workspaceId: String) =
-        wrWebClient.post("${Urls.AI_HUB}/documents/") {
+    private suspend fun sendToAiHub(documents: List<Document>, workspaceId: String): Boolean {
+        val aiHubUrl = Urls.AI_HUB ?: return true
+
+        return wrWebClient.post("$aiHubUrl/documents/") {
             contentType(ContentType.Application.Json)
             setBody(SendDocumentsRequest(documents.map { it.toApi() }, workspaceId))
-        }.status
-            .isSuccess()
+        }.status.isSuccess()
+    }
 
     fun countDocumentsByWorkspaceId(workspaceId: String, writeopiaDb: WriteopiaDbBackend): Long {
         return writeopiaDb.documentEntityQueries.countByWorkspaceId(workspaceId).executeAsOne()

--- a/backend/documents/documents/src/main/java/io/writeopia/api/documents/search/SearchService.kt
+++ b/backend/documents/documents/src/main/java/io/writeopia/api/documents/search/SearchService.kt
@@ -28,7 +28,9 @@ object SearchDocument {
     }
 
     private suspend fun semanticSearch(query: String, workspaceId: String): ResultData<List<String>> {
-        val request = wrWebClient.get("${Urls.AI_HUB}/documents/search/?q=${query}") {
+        val aiHubUrl = Urls.AI_HUB ?: return ResultData.Complete(emptyList())
+
+        val request = wrWebClient.get("$aiHubUrl/documents/search/?q=${query}") {
             contentType(ContentType.Application.Json)
         }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Search now runs within the currently active workspace, returning relevant workspace documents.
  - AI Hub connections can be configured through the deployment environment.

- **Bug Fixes**
  - Blank searches no longer trigger unnecessary requests.
  - Document delivery and semantic search now handle unavailable AI Hub configurations gracefully instead of sending invalid requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->