### PR TITLE
Add llmman as a local AI backend alongside Ollama

### DIFF
--- a/application/core/ollama/src/commonMain/kotlin/io/writeopia/api/OllamaApi.kt
+++ b/application/core/ollama/src/commonMain/kotlin/io/writeopia/api/OllamaApi.kt
@@ -236,6 +236,13 @@ class OllamaApi(
 
     companion object {
         fun defaultUrl() = "http://localhost:11434"
+
+        /**
+         * Base URL of llmman (https://github.com/llmmanorg/llmman), a local model runner
+         * that serves the Ollama API on port 17434. Everything in this class works
+         * unchanged against it; only the port differs.
+         */
+        fun llmmanUrl() = "http://localhost:17434"
     }
 }
 

--- a/documentation/writeopia_docs/docs/application/getting-started/ai/ai.mdx
+++ b/documentation/writeopia_docs/docs/application/getting-started/ai/ai.mdx
@@ -35,6 +35,15 @@ You can follow this video to install it:
     width="100%"       
     height="600px" />
 
+### Using llmman instead of Ollama
+[llmman](https://github.com/llmmanorg/llmman) is a local model runner that serves the Ollama API (alongside OpenAI- and Anthropic-compatible ones) on port 17434, so Writeopia can use it in place of Ollama.
+
+- Install it: `curl -fsSL https://raw.githubusercontent.com/llmmanorg/llmman/main/install.sh | sh` (Linux/macOS) or `irm https://raw.githubusercontent.com/llmmanorg/llmman/main/install.ps1 | iex` (Windows).
+- Start the server with `llmman serve`, and pull a model with `llmman pull gemma4`.
+- In Writeopia, open Settings and change the AI URL from `http://localhost:11434` to `http://localhost:17434`.
+
+Models can be pulled from any OCI registry or straight from Hugging Face (for example `hf.co/unsloth/Qwen3.5-0.8B-GGUF`), and downloading, listing and deleting models from Writeopia's settings work the same way as with Ollama.
+
 ### Selecting an AI Agent
 If you download more models. You will be able to select different models are use them as you prefer. 
 


### PR DESCRIPTION
Adds [llmman](https://github.com/llmmanorg/llmman), a local model runner that serves the Ollama API (alongside OpenAI- and Anthropic-compatible ones) on port 17434.

- Writeopia's Ollama integration is a single user-configurable base URL hitting `/api/generate`, `/api/pull`, `/api/delete` and `/api/tags`. llmman serves all of these, so no new client code is needed; only the port differs (17434 vs 11434).
- `documentation/.../ai/ai.mdx`: new "Using llmman instead of Ollama" section with install, `llmman serve` / `llmman pull`, and the URL to enter in Settings. Placed right after the Ollama setup section.
- `OllamaApi.kt`: adds `llmmanUrl()` next to `defaultUrl()` as a named preset so the port lives in code, not only in docs. It is not wired into the UI yet to keep this change minimal; happy to drop it or add a "use llmman" preset in the settings dialog if preferred.
- No new strings, icons or i18n entries were added; llmman is reached through the existing Ollama settings screen.

**Testing:** Attempted `./gradlew :application:core:ollama:compileKotlinJvm`; it failed before compiling because the project requires a JDK 21 toolchain which is not installed on this machine (no toolchain download repository configured). The Kotlin change is a one-line companion function mirroring `defaultUrl()` and was verified by inspection; it matches the file's indentation and ktlint config (`.editorconfig`).

Not verified: no compile of the touched module, no run against a live llmman or Ollama server, docs site not built.

> AI-assisted, reviewed before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for connecting Writeopia to a locally running, Ollama-compatible model server.
  - Provided a dedicated local server address for AI model requests.

- **Documentation**
  - Added setup guidance covering installation, server startup, model downloads, and Writeopia configuration.
  - Documented support for models from OCI registries and Hugging Face.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->