### PR TITLE
Resources fix for web

### DIFF
--- a/application/web/build.gradle.kts
+++ b/application/web/build.gradle.kts
@@ -34,6 +34,7 @@ kotlin {
                 implementation(compose.runtime)
                 implementation(compose.foundation)
                 implementation(compose.material3)
+                implementation(compose.components.resources)
 
                 implementation(project(":writeopia"))
                 implementation(project(":writeopia_ui"))

--- a/application/web/src/jsMain/kotlin/io/writeopia/web/MainWeb.kt
+++ b/application/web/src/jsMain/kotlin/io/writeopia/web/MainWeb.kt
@@ -46,9 +46,18 @@ import io.writeopia.ui.keyboard.KeyboardEvent
 import kotlinx.browser.window
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.filterNotNull
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.configureWebResources
 
-@OptIn(ExperimentalComposeUiApi::class)
+@OptIn(ExperimentalComposeUiApi::class, ExperimentalResourceApi::class)
 fun main() {
+    // Configure web resources to use absolute paths from the domain root.
+    // This is required for client-side routing (e.g., /site/{documentId}) where
+    // relative paths would incorrectly resolve based on the current URL path.
+    configureWebResources {
+        resourcePathMapping { path -> "/$path" }
+    }
+
     ComposeViewport {
         ImageLoadConfig.configImageLoad()
 

--- a/application/web/src/jsMain/kotlin/resources/index.html
+++ b/application/web/src/jsMain/kotlin/resources/index.html
@@ -5,7 +5,7 @@
     <title>Writeopia</title>
 
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="preload" href="./composeResources/writeopia.application.core.resources.generated.resources/font/Roboto-Regular.ttf" as="fetch" type="font/ttf" crossorigin/>
+    <link rel="preload" href="/composeResources/writeopia.application.core.resources.generated.resources/font/Roboto-Regular.ttf" as="fetch" type="font/ttf" crossorigin/>
     <script src="skiko.js"> </script>
 
     <style>

--- a/application/web/src/wasmJsMain/kotlin/resources/index.html
+++ b/application/web/src/wasmJsMain/kotlin/resources/index.html
@@ -5,7 +5,7 @@
     <title>Writeopia</title>
 
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="preload" href="./composeResources/writeopia.application.core.resources.generated.resources/font/Roboto-Regular.ttf" as="fetch" type="font/ttf" crossorigin/>
+    <link rel="preload" href="/composeResources/writeopia.application.core.resources.generated.resources/font/Roboto-Regular.ttf" as="fetch" type="font/ttf" crossorigin/>
 
     <style>
         /* Basic styles to ensure the Compose content fills the entire viewport.


### PR DESCRIPTION
# Fixing resources for webapp

After this fix, this public page should work: https://app.writeopia.io/site/TuDVQ0EHsZ



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed resource loading for client-side routes such as `/site/{documentId}` by resolving resources from domain-root paths.
  - Improved web application initialization to ensure resources are configured before the viewport is set up.
  - Fixed Roboto font loading across web application builds by using root-relative resource paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->