### PR TITLE
ci: generate ephemeral JWT keys when secrets are unavailable

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -59,6 +59,13 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v7
+      - name: Generate ephemeral JWT keys (fork PRs have no secrets)
+        if: env.JWT_PRIVATE_KEY == ''
+        run: |
+          openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out "$RUNNER_TEMP/jwt.key"
+          openssl rsa -in "$RUNNER_TEMP/jwt.key" -pubout -out "$RUNNER_TEMP/jwt.pub"
+          { echo 'JWT_PRIVATE_KEY<<EOF'; cat "$RUNNER_TEMP/jwt.key"; echo 'EOF'; } >> "$GITHUB_ENV"
+          { echo 'JWT_PUBLIC_KEY<<EOF'; cat "$RUNNER_TEMP/jwt.pub"; echo 'EOF'; } >> "$GITHUB_ENV"
       - name: Set up JDK 21
         uses: actions/setup-java@v6
         with:
@@ -105,6 +112,13 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v7
+      - name: Generate ephemeral JWT keys (fork PRs have no secrets)
+        if: env.JWT_PRIVATE_KEY == ''
+        run: |
+          openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out "$RUNNER_TEMP/jwt.key"
+          openssl rsa -in "$RUNNER_TEMP/jwt.key" -pubout -out "$RUNNER_TEMP/jwt.pub"
+          { echo 'JWT_PRIVATE_KEY<<EOF'; cat "$RUNNER_TEMP/jwt.key"; echo 'EOF'; } >> "$GITHUB_ENV"
+          { echo 'JWT_PUBLIC_KEY<<EOF'; cat "$RUNNER_TEMP/jwt.pub"; echo 'EOF'; } >> "$GITHUB_ENV"
       - name: Set up JDK 21
         uses: actions/setup-java@v6
         with:
@@ -180,6 +194,13 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v7
+      - name: Generate ephemeral JWT keys (fork PRs have no secrets)
+        if: env.JWT_PRIVATE_KEY == ''
+        run: |
+          openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out "$RUNNER_TEMP/jwt.key"
+          openssl rsa -in "$RUNNER_TEMP/jwt.key" -pubout -out "$RUNNER_TEMP/jwt.pub"
+          { echo 'JWT_PRIVATE_KEY<<EOF'; cat "$RUNNER_TEMP/jwt.key"; echo 'EOF'; } >> "$GITHUB_ENV"
+          { echo 'JWT_PUBLIC_KEY<<EOF'; cat "$RUNNER_TEMP/jwt.pub"; echo 'EOF'; } >> "$GITHUB_ENV"
       - name: Set up JDK 21
         uses: actions/setup-java@v6
         with:


### PR DESCRIPTION
Follow-up to #786, as requested by @leandroBorgesFerreira after merging: make `Backend - build`, `General - Build debug` and `Jvm UI Compose tests` pass on fork PRs.

- GitHub gives no secrets to `pull_request` runs from forks, so `JWT_PRIVATE_KEY`/`JWT_PUBLIC_KEY` are empty and `JwtConfig` throws `InvalidKeySpecException` at `InstallAuth.kt:19`.
- Adds one step to each of the three jobs that read `secrets.JWT_*_CI`: when `env.JWT_PRIVATE_KEY == ''`, generate a throwaway 2048-bit RSA keypair with `openssl` and export it via `$GITHUB_ENV`. Runs with real secrets (same-repo branches, `main-merge.yml`) are untouched.
- Uses `openssl genpkey` (always PKCS#8 `BEGIN PRIVATE KEY`) and `openssl rsa -pubout` (SPKI `BEGIN PUBLIC KEY`), which is exactly the format `JwtConfig.loadPrivateKey`/`loadPublicKey` strip and decode. `genrsa` was avoided because on older OpenSSL it emits PKCS#1 `BEGIN RSA PRIVATE KEY`, which the parser would reject.
- Workflow-only change; no Kotlin or Gradle changes.

Testing: ran the step body locally with `RUNNER_TEMP`/`GITHUB_ENV` stubbed, stripped headers and whitespace and base64-decoded the way `JwtConfig` does, and re-parsed the DER as PKCS#8/SPKI successfully; YAML validated. This PR itself comes from a fork, so the CI run here exercises the new path.

> AI-assisted, reviewed before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved automated test and build reliability by generating temporary JWT keys when the configured secret is unavailable.
  * UI, general build, and backend build checks can now continue without requiring a private JWT secret.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->