### PR TITLE
Feat/add document image header endpoint

### DIFF
--- a/backend/core/buckets/src/main/java/io/writeopia/buckets/GcpBucketImageStorageService.kt
+++ b/backend/core/buckets/src/main/java/io/writeopia/buckets/GcpBucketImageStorageService.kt
@@ -60,6 +60,10 @@ object GcpBucketImageStorageService : ImageStorageService {
             uploadedUrl
         }
 
+    /**
+     * Generates a new signed URL for an existing image.
+     * Useful for refreshing expired URLs.
+     */
     suspend fun refreshSignedUrl(
         bucketName: String,
         objectPath: String,

--- a/backend/core/buckets/src/main/java/io/writeopia/buckets/GcpBucketImageStorageService.kt
+++ b/backend/core/buckets/src/main/java/io/writeopia/buckets/GcpBucketImageStorageService.kt
@@ -30,26 +30,29 @@ object GcpBucketImageStorageService : ImageStorageService {
 
             multipart.forEachPart { part ->
                 if (part is PartData.FileItem) {
-                    val fileName =
-                        "uploads/$userId/${System.currentTimeMillis()}-${part.originalFileName}"
+                    if (debugMode) {
+                        uploadedUrl = "https://images.unsplash.com/photo-1579546929518-9e396f3cc809"
+                    } else {
+                        val fileName =
+                            "uploads/$userId/${System.currentTimeMillis()}-${part.originalFileName}"
 
-                    val blobInfo =
-                        BlobInfo.newBuilder(bucketName, fileName)
-                            .setContentType(part.contentType?.toString())
-                            .build()
+                        val blobInfo =
+                            BlobInfo.newBuilder(bucketName, fileName)
+                                .setContentType(part.contentType?.toString())
+                                .build()
 
                     val bytes = part.streamProvider().readBytes()
                     storage.create(blobInfo, bytes)
 
-                    // Generate a signed URL for private access
-                    val blobId = BlobId.of(bucketName, fileName)
-                    val signedUrl = storage.signUrl(
-                        BlobInfo.newBuilder(blobId).build(),
-                        SIGNED_URL_EXPIRATION_DAYS,
-                        TimeUnit.DAYS
-                    )
+                        val blobId = BlobId.of(bucketName, fileName)
+                        val signedUrl = storage.signUrl(
+                            BlobInfo.newBuilder(blobId).build(),
+                            SIGNED_URL_EXPIRATION_DAYS,
+                            TimeUnit.DAYS
+                        )
 
-                    uploadedUrl = signedUrl.toString()
+                        uploadedUrl = signedUrl.toString()
+                    }
                 }
                 part.dispose()
             }
@@ -57,10 +60,6 @@ object GcpBucketImageStorageService : ImageStorageService {
             uploadedUrl
         }
 
-    /**
-     * Generates a new signed URL for an existing image.
-     * Useful for refreshing expired URLs.
-     */
     suspend fun refreshSignedUrl(
         bucketName: String,
         objectPath: String,

--- a/backend/core/buckets/src/main/java/io/writeopia/buckets/GcpBucketImageStorageService.kt
+++ b/backend/core/buckets/src/main/java/io/writeopia/buckets/GcpBucketImageStorageService.kt
@@ -10,7 +10,7 @@ import java.util.concurrent.TimeUnit
 
 object GcpBucketImageStorageService : ImageStorageService {
 
-    private val storage = GcpStorageProvider.storage
+    private val storage by lazy { GcpStorageProvider.storage } // Don't run when it's not accessed useful in debug mode
 
     // Signed URL expiration time (7 days)
     private const val SIGNED_URL_EXPIRATION_DAYS = 7L
@@ -31,7 +31,7 @@ object GcpBucketImageStorageService : ImageStorageService {
             multipart.forEachPart { part ->
                 if (part is PartData.FileItem) {
                     if (debugMode) {
-                        uploadedUrl = "https://images.unsplash.com/photo-1579546929518-9e396f3cc809"
+                        uploadedUrl = "https://picsum.photos/200"
                     } else {
                         val fileName =
                             "uploads/$userId/${System.currentTimeMillis()}-${part.originalFileName}"
@@ -41,8 +41,8 @@ object GcpBucketImageStorageService : ImageStorageService {
                                 .setContentType(part.contentType?.toString())
                                 .build()
 
-                    val bytes = part.streamProvider().readBytes()
-                    storage.create(blobInfo, bytes)
+                        val bytes = part.streamProvider().readBytes()
+                        storage.create(blobInfo, bytes)
 
                         val blobId = BlobId.of(bucketName, fileName)
                         val signedUrl = storage.signUrl(

--- a/backend/core/database/src/main/sqldelight/io/writeopia/sql/DocumentEntity.sq
+++ b/backend/core/database/src/main/sqldelight/io/writeopia/sql/DocumentEntity.sq
@@ -12,7 +12,8 @@ CREATE TABLE document_entity (
   is_locked BOOLEAN NOT NULL,
   company_id TEXT NULL,
   deleted BOOLEAN NOT NULL,
-  published BOOLEAN NOT NULL DEFAULT FALSE
+  published BOOLEAN NOT NULL DEFAULT FALSE,
+  header_image TEXT
 );
 
 selectAll:
@@ -189,3 +190,11 @@ selectIdsByWorkspaceId:
 SELECT id
 FROM document_entity
 WHERE workspace_id = ? AND deleted = FALSE;
+
+updateHeaderImage:
+UPDATE document_entity
+SET 
+  header_image = ?, 
+  last_updated_at = ?, 
+  last_synced = ? 
+WHERE id = ? AND workspace_id = ? AND deleted = FALSE;

--- a/backend/documents/documents/src/main/java/io/writeopia/api/documents/routing/DocumentsRouting.kt
+++ b/backend/documents/documents/src/main/java/io/writeopia/api/documents/routing/DocumentsRouting.kt
@@ -1150,7 +1150,6 @@ fun Routing.documentsRoute(
                     workspace_id = workspaceId
                 )
 
-
                 call.respond(
                     HttpStatusCode.OK,
                     mapOf("headerImage" to imageUrl, "documentId" to documentId)
@@ -1158,5 +1157,4 @@ fun Routing.documentsRoute(
             }
         }
     }
-
 }

--- a/backend/documents/documents/src/main/java/io/writeopia/api/documents/routing/DocumentsRouting.kt
+++ b/backend/documents/documents/src/main/java/io/writeopia/api/documents/routing/DocumentsRouting.kt
@@ -1124,5 +1124,39 @@ fun Routing.documentsRoute(
             }
         }
     }
-}
 
+    authenticate("auth-jwt", optional = debug) {
+        post("/api/docs/workspace/{workspaceId}/document/{documentId}/header") {
+            val userId = getUserId() ?: ""
+            val workspaceId = call.pathParameters["workspaceId"] ?: ""
+            val documentId = call.pathParameters["documentId"] ?: ""
+
+            runIfMember(userId, workspaceId, writeopiaDb, debug) {
+                val multipart = call.receiveMultipart()
+
+                val imageUrl = imageStorageService.uploadImage(multipart, userId, debug)
+
+                if (imageUrl == null) {
+                    call.respond(HttpStatusCode.BadRequest, "No image found in request")
+                    return@runIfMember
+                }
+
+                val now = System.currentTimeMillis()
+                writeopiaDb.documentEntityQueries.updateHeaderImage(
+                    header_image = imageUrl,
+                    last_updated_at = now,
+                    last_synced = now,
+                    id = documentId,
+                    workspace_id = workspaceId
+                )
+
+
+                call.respond(
+                    HttpStatusCode.OK,
+                    mapOf("headerImage" to imageUrl, "documentId" to documentId)
+                )
+            }
+        }
+    }
+
+}

--- a/backend/gateway/src/test/kotlin/io/writeopia/api/gateway/DocumentsIntegrationTest.kt
+++ b/backend/gateway/src/test/kotlin/io/writeopia/api/gateway/DocumentsIntegrationTest.kt
@@ -2,6 +2,10 @@
 
 package io.writeopia.api.gateway
 
+import io.ktor.client.request.forms.formData
+import io.ktor.client.request.forms.submitFormWithBinaryData
+import io.ktor.http.Headers
+import io.ktor.http.HttpHeaders
 import io.ktor.client.call.body
 import io.ktor.client.request.delete
 import io.ktor.client.request.get
@@ -1756,5 +1760,61 @@ class DocumentationIntegrationTests {
 
         // Clean up
         db.deleteDocumentById(document.id)
+    }
+
+    @Test
+    fun `it should be possible to upload document header image`() = testApplication {
+        application {
+            module(db, debugMode = true)
+        }
+
+        val client = defaultClient()
+        val workspace = Random.nextInt().toString()
+        val docId = "test_doc_header_${Random.nextInt()}"
+
+        val now = System.currentTimeMillis()
+        db.documentEntityQueries.insert(
+            id = docId,
+            title = "Test Note for Header",
+            created_at = now,
+            last_updated_at = now,
+            last_synced = now,
+            workspace_id = workspace,
+            favorite = false,
+            parent_document_id = "root",
+            icon = null,
+            icon_tint = null,
+            is_locked = false,
+            company_id = null,
+            deleted = false,
+            published = false
+        )
+
+        val response = client.submitFormWithBinaryData(
+            url = "/api/docs/workspace/$workspace/document/$docId/header",
+            formData = formData {
+                append(
+                    key = "image",
+                    value = byteArrayOf(1, 2, 3, 4),
+                    headers = Headers.build {
+                        append(HttpHeaders.ContentType, "image/png")
+                        append(HttpHeaders.ContentDisposition, "filename=\"test.png\"")
+                    }
+                )
+            }
+        )
+
+        assertEquals(HttpStatusCode.OK, response.status)
+
+        val updatedDoc = db.documentEntityQueries.selectById(
+            id = docId,
+            workspace_id = workspace
+        ).executeAsOne()
+
+        assertTrue(updatedDoc.header_image != null && updatedDoc.header_image!!.isNotEmpty())
+        assertTrue(updatedDoc.last_updated_at >= now)
+        assertTrue(updatedDoc.last_synced >= now)
+
+        db.deleteDocumentById(docId)
     }
 }

--- a/docker/postgres/init.sql
+++ b/docker/postgres/init.sql
@@ -12,7 +12,8 @@ CREATE TABLE document_entity (
   is_locked BOOLEAN NOT NULL,
   company_id TEXT NULL,
   deleted BOOLEAN NOT NULL,
-  published BOOLEAN NOT NULL DEFAULT FALSE
+  published BOOLEAN NOT NULL DEFAULT FALSE,
+  header_image TEXT 
 );
 
 CREATE TABLE story_step_entity (


### PR DESCRIPTION
#803 

Add document header image upload endpoint

- Add POST /api/docs/.../document/{documentId}/header to upload and
  persist a document's header image
- Add header_image column + updateHeaderImage query to document_entity
- Lazily init GCP storage and return a placeholder URL in debug mode
- Cover the flow with a gateway integration test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for uploading header images to documents.
  - Uploaded image URLs are associated with the selected document.
  - Added a document header image field.
- **Bug Fixes**
  - In debug mode, image uploads now use a placeholder image instead of external storage.
- **Tests**
  - Added integration coverage for header image uploads, persistence, and timestamp updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->